### PR TITLE
Prefer pointer types in prefix operator parsing

### DIFF
--- a/src/toolsrc/parse.c
+++ b/src/toolsrc/parse.c
@@ -651,9 +651,13 @@ t_opseq *parse_value(t_opseq *codeseq, int rvalue, int *stackdepth)
             cfnparms = 0; cfnvals = 1;
             type &= ~FUNC_TYPE;
         }
-        else if (type & (BYTE_TYPE | BPTR_TYPE))
+        else if (type & (BPTR_TYPE)) // Prefer the pointer type.
             valseq = gen_lb(valseq);
-        else if (type & (WORD_TYPE | WPTR_TYPE))
+        else if (type & (WPTR_TYPE))
+            valseq = gen_lw(valseq);
+        else if (type & (BYTE_TYPE))
+            valseq = gen_lb(valseq);
+        else if (type & (WORD_TYPE))
             valseq = gen_lw(valseq);
         else
             parse_error("What are we dereferencing?");

--- a/src/toolsrc/parse.pla
+++ b/src/toolsrc/parse.pla
@@ -461,9 +461,13 @@ def parse_value(codeseq, r_val)#2
             valseq     = gen_op(valseq, ICAL_CODE)
             stackdepth = stackdepth + cfnvals - 1
             type       = type & ~FUNC_TYPE
-        elsif type & (BYTE_TYPE | BPTR_TYPE)
+        elsif type & (BPTR_TYPE)  // Prefer the pointer type.
             valseq = gen_op(valseq, LB_CODE)
-        elsif type & (WORD_TYPE | WPTR_TYPE)
+        elsif type & (WPTR_TYPE)
+            valseq = gen_op(valseq, LW_CODE)
+        elsif type & (BYTE_TYPE)
+            valseq = gen_op(valseq, LB_CODE)
+        elsif type & (WORD_TYPE)
             valseq = gen_op(valseq, LW_CODE)
         else
             exit_err(ERR_INVAL|ERR_CODE)


### PR DESCRIPTION
This fixes issue #49 in the simplest way. Before, if the
dereferenced variable was a byte type, the result of the word
pointer dereference operator, `*`, would be a byte type. This
caused `*@a` to return a byte if `a` was a byte type. Now the
pointer type is used instead, causing `*@a` to return a word.

Prefix operator parsing allows some nonsensical constructions,
like `@*x`, but these were already possible before.

Before the output from:
```
include "inc/cmdsys.plh"

byte a
byte b
word x

a = 5
b = 6
x = $55FF
puti(*@a) // 5
putln()
puti(*(@a)) // 1541
putln()
puti(@*a) // 5
putln()
puti(^@x) // 255
putln()
puti(^(@x)) // 255
putln()
puti(@^x) // 255
putln()
done
```
was:
```
5
1541
5
255
255
255
```
now it is:
```
1541
1541
1541
255
255
255
```