### PR TITLE
Remove duplicate 'res' token declarations

### DIFF
--- a/src/toolsrc/lex.c
+++ b/src/toolsrc/lex.c
@@ -50,7 +50,6 @@ t_token keywords[] = {
     BYTE_TOKEN,             'R', 'E', 'S',
     BYTE_TOKEN,             'B', 'Y', 'T', 'E',
     BYTE_TOKEN,             'C', 'H', 'A', 'R',
-    BYTE_TOKEN,             'R', 'E', 'S',
     WORD_TOKEN,             'W', 'O', 'R', 'D',
     WORD_TOKEN,             'V', 'A', 'R',
     CONST_TOKEN,            'C', 'O', 'N', 'S', 'T',

--- a/src/toolsrc/plasm.pla
+++ b/src/toolsrc/plasm.pla
@@ -152,7 +152,6 @@ byte                    = "AND",      LOGIC_AND_TKN
 byte                    = "NOT",      LOGIC_NOT_TKN
 byte                    = "RES",      BYTE_TKN
 byte                    = "VAR",      WORD_TKN
-byte                    = "RES",      BYTE_TKN
 byte                    = "WORD",     WORD_TKN
 byte                    = "CHAR",     BYTE_TKN
 byte                    = "BYTE",     BYTE_TKN


### PR DESCRIPTION
Before this change, there were two declarations for the `res` token in
both `lex.c` and `plasm.pla`. Now there is only one.